### PR TITLE
docs: WHMCS products & addons feature scope

### DIFF
--- a/docs/scope.md
+++ b/docs/scope.md
@@ -1,0 +1,202 @@
+# WHMCS Scope — Products & Addons
+
+Source: WHMCS top-nav Products + Addons menus, scraped page-by-page from https://www.whmcs.com/ on 2026-06-26. Organised functionality-by-functionality. Marketing-only nav items (Feature Tour overview, Videos, What's New) are not feature pages and are omitted except where the tour adds platform-level capabilities.
+
+---
+
+## Web Hosting (Account Provisioning)
+Source: https://www.whmcs.com/web-hosting/
+
+- **Account provisioning** — create, suspend, modify, terminate accounts across a server fleet.
+- **Single sign-on** — one customer login for access to all their services.
+- **Upgrades / downgrades** — auto-adjust hosting account capacity on customer request.
+- **Control panel integration** — cPanel, Plesk, DirectAdmin, SolusVM, Interworx.
+- **cPanel integration** — billing/support access inside cPanel UI with unified login.
+- **Order form customization** — design templates: Premium, Pure, Supreme, Universal Slider, Cloud Slider.
+- **Automatic suspension** — suspend overdue/delinquent accounts.
+- **Payment management** — automated reminders + overdue notices on failed transactions.
+- **Account synchronization** — sync and import accounts from cPanel servers.
+- **Configurable options** — customizable add-ons offered during ordering.
+- **Client portal** — self-service management of hosting services.
+- **Auto-updates** — auto-download and install product updates.
+- **Usage statistics** — daily disk/bandwidth import; usage-based billing.
+- **Domain resolver** — detect domains removed from your nameservers.
+- **Product bundles** — group related products/services.
+
+---
+
+## Sell Domains (Domain Reselling)
+Source: https://www.whmcs.com/sell-domains/
+
+**Core domain management**
+- **Automated registration** — integration with major registrars.
+- **Real-time availability** — WHOIS + registrar API polling.
+- **Domain transfers** — auto EPP code request, transfer init, status monitoring.
+- **Automated renewals** — auto-invoice, trigger registry renewal on payment.
+- **Domain syncing** — daily sync of due dates, status, transfer-away detection.
+
+**Customer-facing**
+- **Self-service portal** — customers manage all registration aspects.
+- **Domain search** — availability check embedded on your website.
+- **WHOIS lookup** — on-demand WHOIS view.
+- **Namespinning** — smart domain suggestions to lift conversions.
+- **Spotlight TLDs** — feature top/premium extensions with logos.
+
+**Technical**
+- **Nameserver management** — admin + customer view/modify.
+- **WHOIS management** — real-time edit of registry contact info.
+- **DNS management** — customer view/manage DNS host records.
+- **ID protection** — WHOIS privacy with upgrade option.
+- **Premium domains** — premium sales with auto markup tiers.
+- **Free domains** — bundle registration with hosting.
+
+**Registrar integrations** — eNom, CentralNic Reseller, ResellerClub, Nominet, OpenSRS, + more.
+
+---
+
+## Billing Automation
+Source: https://www.whmcs.com/billing-automation/
+
+**Core billing**
+- **PDF invoices** — professional invoices + receipts.
+- **Recurring billing** — auto invoice generation + payment capture for subscriptions.
+- **Payment reminders** — auto notices for failed/overdue payments.
+
+**Payment processing**
+- **Credit card processing** — direct merchant gateway integration.
+- **Off-site gateways** — PayPal, 2CheckOut (reduced compliance burden).
+- **Tokenised storage** — secure card storage, reduced liability.
+- **PayPal** — Standard, Express Checkout, Pro, PayFlow Pro.
+- **ACH / SEPA / Direct Debit** — bank payments for US, UK, EU.
+- **iDEAL** — iDEAL banking payments.
+- **Offline payments** — check / mail-in.
+
+**Financial management**
+- **Multi-currency** — invoice in different currencies.
+- **Tax / VAT** — sales tax + EU VAT, multiple levels.
+- **Coupons & promotions** — fixed or % discount codes.
+- **Quotes** — online quote generation + acceptance.
+- **Refunds & disputes** — direct refunds, automated dispute handling.
+- **Late fees** — fixed or % overdue fees.
+- **On-demand capture** — charge cards / tokenized gateways as needed.
+
+**Billing flexibility**
+- **Billing cycles** — one-time or recurring up to every 3 years.
+- **Proration** — fixed-day billing with upgrade proration.
+- **Upgrades / changes** — mid-cycle upgrades with auto account update.
+- **Draft invoices** — unpublished invoices before delivery.
+- **Email notifications** — auto confirmations for all transactions.
+
+---
+
+## Integrated Support Tools
+Source: https://www.whmcs.com/integrated-support-tools/
+
+- **Support ticketing** — central help desk: departments, email piping, ticket assignment, custom fields, escalation rules, file attachments.
+- **Knowledgebase** — searchable self-service; auto-suggests articles on ticket submit.
+- **Announcements** — news/offers in client portal with social sharing.
+- **Downloads** — host/deliver manuals, templates, software; sell restricted access to files.
+- **Network status** — alert customers to maintenance, downtime, disruptions.
+- **Integration** — quick access to customer profiles, service management, billing alongside support.
+
+---
+
+## cPanel & WHM
+Source: https://www.whmcs.com/for/cpanel/
+
+**Hosting & provisioning**
+- Automated cPanel account creation.
+- cPanel/WHM account importer.
+- Ready-made order forms.
+- Domain registrar integration.
+
+**Billing & payment**
+- Recurring payment collection.
+- Professional invoicing.
+- Automated suspensions on overdue.
+- Automatic reactivation on payment.
+
+**Account management**
+- Auto suspension & reactivation (payment-based).
+- Remote password resets (no direct cPanel access).
+- Automatic signin/transfer — seamless redirect to cPanel.
+
+**Monitoring & reporting**
+- Integrated disk & bandwidth usage reporting.
+- Resource usage tracking, centralized.
+
+**SSO & integration**
+- cPanel single sign-on.
+- WHMCS Connect — server management inside WHMCS.
+- cPanel OpenID integration.
+- Integrated billing/support links inside cPanel.
+
+**Administrative**
+- Package synchronization (WHMCS ↔ WHM).
+- Ticketing system.
+- Self-service tools.
+
+**Platform**
+- App marketplace (hundreds of integrations).
+- Developer API.
+
+---
+
+## Addon: Project Management
+Source: https://www.whmcs.com/project-management/
+
+- **Projects** — central place for files, discussions, tasks.
+- **Time tracking** — log time per task, start/stop timer per admin.
+- **Task tracking** — task lists, completion marking, outstanding-work visibility.
+- **Due date tracking** — deadlines, priority by time remaining.
+- **Time-to-invoice** — convert logged time into customer invoices.
+- **Ticketing integration** — link tickets to projects; create project from ticket.
+- **Staff messageboard** — private per-project staff notes.
+- **File sharing** — attach/centralize files, customer access.
+- **Invoice integration** — project invoice history, payment status, new invoices.
+- **Reporting** — projects, time worked, stats.
+- **Detailed logging** — audit trail of changes, who, when.
+- **Multi-language** — translate client-facing UI.
+- **Client portal** — customers see status, communication, shared files.
+
+---
+
+## Addon: SSL Automation
+Source: https://www.whmcs.com/ssl-automation/
+
+- **Instant setup** — start selling in minutes, minimal config.
+- **Auto product population** — pick DigiCert certs, auto-added as sellable products.
+- **Ready-made landing pages** — DV, OV, EV, Wildcard cert pages.
+- **Fully automated issuance/installation** — issue, deploy, install across cPanel, Plesk, DirectAdmin.
+- **Integrated cert management** — all ops inside WHMCS.
+- **Competitive upgrade** — migrate from competing providers, preserve validity.
+- **Built-in upsells** — promote OV/EV at hosting purchase/checkout.
+- **Customer self-service** — purchase + install in a few clicks.
+- **DigiCert integration** — RapidSSL, GeoTrust brands.
+
+---
+
+## Addon: Software Licensing
+Source: https://www.whmcs.com/software-licensing/
+
+- **Copy & paste integration** — ready-made PHP SDK.
+- **Local & remote keys** — dual validation; access survives platform downtime.
+- **Self-service portal** — customers manage licenses, status, downloads.
+- **Automatic activation** — activates on install of protected app.
+- **License key generation** — customizable prefix/length.
+- **Download restrictions** — downloads tied to valid license/support.
+- **Add-ons & options** — sell licensed products with controllable extras.
+- **License reissues** — automate transfer to new installs.
+- **Abuse detection** — block fraudulent reissue attempts.
+- **Client portal** — view, reissue, upgrade, download licenses.
+- **Flexible API** — license apps in languages beyond PHP.
+
+---
+
+## Platform-level capabilities (from Feature Tour)
+Source: https://www.whmcs.com/tour/
+
+- Control panel integration: all major panels + 200+ service providers.
+- Developer API for custom development/extensions.
+- Hundreds of apps/integrations (marketplace).
+- Scalability, flexibility, multi-country (200+ countries).


### PR DESCRIPTION
Scope doc covering WHMCS top-nav Products & Addons, functionality-by-functionality.

Source: scraped from whmcs.com on 2026-06-26.

Sections:
- Web Hosting, Sell Domains, Billing Automation, Support Tools, cPanel & WHM
- Addons: Project Management, SSL Automation, Software Licensing
- Platform-level capabilities (Feature Tour)

File: `docs/scope.md`. Marketing-only nav items (Videos, What's New) omitted.