### PR TITLE
Support ticketing depth (departments, assignment, attachments, custom fields, escalation, email piping)

### DIFF
--- a/app/Console/Commands/EscalateTickets.php
+++ b/app/Console/Commands/EscalateTickets.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\TicketEscalationService;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Description('Apply ticket escalation rules to overdue tickets')]
+#[Signature('tickets:escalate')]
+class EscalateTickets extends Command
+{
+    public function handle(TicketEscalationService $service): int
+    {
+        $escalated = $service->escalate();
+
+        $this->info("Escalated {$escalated} tickets");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Filament/Admin/Resources/TicketCustomFields/Pages/CreateTicketCustomField.php
+++ b/app/Filament/Admin/Resources/TicketCustomFields/Pages/CreateTicketCustomField.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketCustomFields\Pages;
+
+use App\Filament\Admin\Resources\TicketCustomFields\TicketCustomFieldResource;
+use Filament\Resources\Pages\CreateRecord;
+use Override;
+
+class CreateTicketCustomField extends CreateRecord
+{
+    #[Override]
+    protected static string $resource = TicketCustomFieldResource::class;
+}

--- a/app/Filament/Admin/Resources/TicketCustomFields/Pages/EditTicketCustomField.php
+++ b/app/Filament/Admin/Resources/TicketCustomFields/Pages/EditTicketCustomField.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketCustomFields\Pages;
+
+use App\Filament\Admin\Resources\TicketCustomFields\TicketCustomFieldResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Override;
+
+class EditTicketCustomField extends EditRecord
+{
+    #[Override]
+    protected static string $resource = TicketCustomFieldResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/TicketCustomFields/Pages/ListTicketCustomFields.php
+++ b/app/Filament/Admin/Resources/TicketCustomFields/Pages/ListTicketCustomFields.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketCustomFields\Pages;
+
+use App\Filament\Admin\Resources\TicketCustomFields\TicketCustomFieldResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Override;
+
+class ListTicketCustomFields extends ListRecords
+{
+    #[Override]
+    protected static string $resource = TicketCustomFieldResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/TicketCustomFields/Schemas/TicketCustomFieldForm.php
+++ b/app/Filament/Admin/Resources/TicketCustomFields/Schemas/TicketCustomFieldForm.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketCustomFields\Schemas;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TagsInput;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+class TicketCustomFieldForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('label')
+                    ->required()
+                    ->maxLength(255),
+                Select::make('type')
+                    ->options([
+                        'text' => 'Text',
+                        'select' => 'Select',
+                        'number' => 'Number',
+                        'checkbox' => 'Checkbox',
+                    ])
+                    ->default('text')
+                    ->live()
+                    ->required(),
+                Select::make('department_id')
+                    ->relationship('department', 'name')
+                    ->label('Department')
+                    ->helperText('Leave empty to apply to all departments.'),
+                TagsInput::make('options')
+                    ->helperText('Choices for a select field.')
+                    ->visible(fn (Get $get): bool => $get('type') === 'select'),
+                Toggle::make('is_required'),
+                Toggle::make('is_active')
+                    ->default(true),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/TicketCustomFields/Tables/TicketCustomFieldsTable.php
+++ b/app/Filament/Admin/Resources/TicketCustomFields/Tables/TicketCustomFieldsTable.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketCustomFields\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class TicketCustomFieldsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('label')
+                    ->searchable(),
+                TextColumn::make('type')
+                    ->badge(),
+                TextColumn::make('department.name')
+                    ->label('Department')
+                    ->placeholder('All'),
+                IconColumn::make('is_required')
+                    ->boolean(),
+                IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/TicketCustomFields/TicketCustomFieldResource.php
+++ b/app/Filament/Admin/Resources/TicketCustomFields/TicketCustomFieldResource.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketCustomFields;
+
+use App\Filament\Admin\Resources\TicketCustomFields\Pages\CreateTicketCustomField;
+use App\Filament\Admin\Resources\TicketCustomFields\Pages\EditTicketCustomField;
+use App\Filament\Admin\Resources\TicketCustomFields\Pages\ListTicketCustomFields;
+use App\Filament\Admin\Resources\TicketCustomFields\Schemas\TicketCustomFieldForm;
+use App\Filament\Admin\Resources\TicketCustomFields\Tables\TicketCustomFieldsTable;
+use App\Models\TicketCustomField;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Override;
+use UnitEnum;
+
+class TicketCustomFieldResource extends Resource
+{
+    #[Override]
+    protected static ?string $model = TicketCustomField::class;
+
+    #[Override]
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedTag;
+
+    #[Override]
+    protected static string|UnitEnum|null $navigationGroup = 'Support';
+
+    #[Override]
+    protected static ?string $navigationLabel = 'Ticket Fields';
+
+    #[Override]
+    public static function form(Schema $schema): Schema
+    {
+        return TicketCustomFieldForm::configure($schema);
+    }
+
+    #[Override]
+    public static function table(Table $table): Table
+    {
+        return TicketCustomFieldsTable::configure($table);
+    }
+
+    #[Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTicketCustomFields::route('/'),
+            'create' => CreateTicketCustomField::route('/create'),
+            'edit' => EditTicketCustomField::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/TicketDepartments/Pages/CreateTicketDepartment.php
+++ b/app/Filament/Admin/Resources/TicketDepartments/Pages/CreateTicketDepartment.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketDepartments\Pages;
+
+use App\Filament\Admin\Resources\TicketDepartments\TicketDepartmentResource;
+use Filament\Resources\Pages\CreateRecord;
+use Override;
+
+class CreateTicketDepartment extends CreateRecord
+{
+    #[Override]
+    protected static string $resource = TicketDepartmentResource::class;
+}

--- a/app/Filament/Admin/Resources/TicketDepartments/Pages/EditTicketDepartment.php
+++ b/app/Filament/Admin/Resources/TicketDepartments/Pages/EditTicketDepartment.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketDepartments\Pages;
+
+use App\Filament\Admin\Resources\TicketDepartments\TicketDepartmentResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Override;
+
+class EditTicketDepartment extends EditRecord
+{
+    #[Override]
+    protected static string $resource = TicketDepartmentResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/TicketDepartments/Pages/ListTicketDepartments.php
+++ b/app/Filament/Admin/Resources/TicketDepartments/Pages/ListTicketDepartments.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketDepartments\Pages;
+
+use App\Filament\Admin\Resources\TicketDepartments\TicketDepartmentResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Override;
+
+class ListTicketDepartments extends ListRecords
+{
+    #[Override]
+    protected static string $resource = TicketDepartmentResource::class;
+
+    /**
+     * @return array<int, mixed>
+     */
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/TicketDepartments/Schemas/TicketDepartmentForm.php
+++ b/app/Filament/Admin/Resources/TicketDepartments/Schemas/TicketDepartmentForm.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketDepartments\Schemas;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Schema;
+
+class TicketDepartmentForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('email')
+                    ->email()
+                    ->maxLength(255)
+                    ->helperText('Inbound address used for email piping into this department.'),
+                Toggle::make('is_active')
+                    ->default(true),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/TicketDepartments/Tables/TicketDepartmentsTable.php
+++ b/app/Filament/Admin/Resources/TicketDepartments/Tables/TicketDepartmentsTable.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketDepartments\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class TicketDepartmentsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable(),
+                TextColumn::make('email')
+                    ->searchable(),
+                TextColumn::make('tickets_count')
+                    ->counts('tickets')
+                    ->label('Tickets'),
+                IconColumn::make('is_active')
+                    ->boolean(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/TicketDepartments/TicketDepartmentResource.php
+++ b/app/Filament/Admin/Resources/TicketDepartments/TicketDepartmentResource.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\TicketDepartments;
+
+use App\Filament\Admin\Resources\TicketDepartments\Pages\CreateTicketDepartment;
+use App\Filament\Admin\Resources\TicketDepartments\Pages\EditTicketDepartment;
+use App\Filament\Admin\Resources\TicketDepartments\Pages\ListTicketDepartments;
+use App\Filament\Admin\Resources\TicketDepartments\Schemas\TicketDepartmentForm;
+use App\Filament\Admin\Resources\TicketDepartments\Tables\TicketDepartmentsTable;
+use App\Models\TicketDepartment;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Override;
+use UnitEnum;
+
+class TicketDepartmentResource extends Resource
+{
+    #[Override]
+    protected static ?string $model = TicketDepartment::class;
+
+    #[Override]
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedInbox;
+
+    #[Override]
+    protected static string|UnitEnum|null $navigationGroup = 'Support';
+
+    #[Override]
+    public static function form(Schema $schema): Schema
+    {
+        return TicketDepartmentForm::configure($schema);
+    }
+
+    #[Override]
+    public static function table(Table $table): Table
+    {
+        return TicketDepartmentsTable::configure($table);
+    }
+
+    #[Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTicketDepartments::route('/'),
+            'create' => CreateTicketDepartment::route('/create'),
+            'edit' => EditTicketDepartment::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/InboundEmailController.php
+++ b/app/Http/Controllers/Api/InboundEmailController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Ticket;
+use App\Services\InboundEmailService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class InboundEmailController extends Controller
+{
+    public function __construct(
+        protected InboundEmailService $inboundEmailService
+    ) {}
+
+    public function store(Request $request): JsonResponse
+    {
+        $payload = $request->validate([
+            'from' => ['required', 'email'],
+            'to' => ['required', 'email'],
+            'subject' => ['nullable', 'string'],
+            'body' => ['nullable', 'string'],
+            'ticket_id' => ['nullable', 'integer'],
+        ]);
+
+        $result = $this->inboundEmailService->handle($payload);
+
+        return response()->json([
+            'type' => $result instanceof Ticket ? 'ticket' : 'response',
+            'id' => $result->id,
+            'ticket_id' => $result instanceof Ticket ? $result->id : $result->ticket_id,
+        ], 201);
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -92,12 +92,21 @@ class TicketController extends Controller
             [
                 'responses.user',
                 'user',
+                'assignee',
+                'department',
             ]
         );
 
+        $staff = User::role(
+            [
+                'admin',
+                'super_admin',
+            ]
+        )->get();
+
         return view(
             'tickets.show',
-            compact('ticket')
+            compact('ticket', 'staff')
         );
     }
 
@@ -122,6 +131,30 @@ class TicketController extends Controller
         return redirect()->back()->with(
             'success',
             'Ticket status updated.'
+        );
+    }
+
+    public function assign(Request $request, Ticket $ticket): RedirectResponse
+    {
+        $this->authorize(
+            'update',
+            $ticket
+        );
+
+        $validated = $request->validate(
+            [
+                'assigned_to' => [
+                    'nullable',
+                    'exists:users,id',
+                ],
+            ]
+        );
+
+        $ticket->update(['assigned_to' => $validated['assigned_to'] ?? null]);
+
+        return redirect()->back()->with(
+            'success',
+            'Ticket assignment updated.'
         );
     }
 }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Ticket;
+use App\Models\TicketAttachment;
+use App\Models\TicketCustomField;
 use App\Models\User;
 use App\Notifications\NewTicketNotification;
 use Illuminate\Contracts\View\Factory;
@@ -10,6 +12,8 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TicketController extends Controller
 {
@@ -34,23 +38,29 @@ class TicketController extends Controller
 
     public function store(Request $request): RedirectResponse
     {
-        $validated = $request->validate(
-            [
-                'title' => [
-                    'required',
-                    'string',
-                    'max:255',
-                ],
-                'description' => [
-                    'required',
-                    'string',
-                ],
-                'priority' => [
-                    'required',
-                    'in:low,medium,high',
-                ],
-            ]
-        );
+        $rules = [
+            'title' => [
+                'required',
+                'string',
+                'max:255',
+            ],
+            'description' => [
+                'required',
+                'string',
+            ],
+            'priority' => [
+                'required',
+                'in:low,medium,high',
+            ],
+        ];
+
+        // Add a rule per admin-defined custom field; required ones must be filled.
+        $customFields = TicketCustomField::active()->get();
+        foreach ($customFields as $field) {
+            $rules["custom_fields.{$field->id}"] = $field->is_required ? ['required'] : ['nullable'];
+        }
+
+        $validated = $request->validate($rules);
 
         $ticket = Ticket::create(
             [
@@ -58,6 +68,7 @@ class TicketController extends Controller
                 'title' => $validated['title'],
                 'description' => $validated['description'],
                 'priority' => $validated['priority'],
+                'custom_fields' => $request->input('custom_fields', []),
             ]
         );
 
@@ -155,6 +166,19 @@ class TicketController extends Controller
         return redirect()->back()->with(
             'success',
             'Ticket assignment updated.'
+        );
+    }
+
+    public function downloadAttachment(TicketAttachment $attachment): StreamedResponse
+    {
+        $this->authorize(
+            'view',
+            $attachment->owningTicket()
+        );
+
+        return Storage::disk('local')->download(
+            $attachment->path,
+            $attachment->original_name
         );
     }
 }

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -12,6 +14,8 @@ use Illuminate\Support\Carbon;
 /**
  * @property int $id
  * @property int $user_id
+ * @property int|null $department_id
+ * @property int|null $assigned_to
  * @property string $title
  * @property string $description
  * @property string $status
@@ -19,10 +23,14 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User|null $user
+ * @property-read TicketDepartment|null $department
+ * @property-read User|null $assignee
  * @property-read Collection<int, TicketResponse> $responses
  */
 #[Fillable([
     'user_id',
+    'department_id',
+    'assigned_to',
     'title',
     'description',
     'status',
@@ -30,9 +38,30 @@ use Illuminate\Support\Carbon;
 ])]
 class Ticket extends Model
 {
+    use HasFactory;
+
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function department(): BelongsTo
+    {
+        return $this->belongsTo(TicketDepartment::class);
+    }
+
+    public function assignee(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'assigned_to');
+    }
+
+    /**
+     * @param  Builder<Ticket>  $query
+     * @return Builder<Ticket>
+     */
+    public function scopeAssignedTo(Builder $query, int $userId): Builder
+    {
+        return $query->where('assigned_to', $userId);
     }
 
     public function responses(): HasMany

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Carbon;
  * @property string $description
  * @property string $status
  * @property string $priority
+ * @property array|null $custom_fields
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read User|null $user
@@ -35,10 +36,21 @@ use Illuminate\Support\Carbon;
     'description',
     'status',
     'priority',
+    'custom_fields',
 ])]
 class Ticket extends Model
 {
     use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'custom_fields' => 'array',
+        ];
+    }
 
     public function user(): BelongsTo
     {

--- a/app/Models/TicketAttachment.php
+++ b/app/Models/TicketAttachment.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $attachable_type
+ * @property int $attachable_id
+ * @property int|null $uploaded_by
+ * @property string $path
+ * @property string $original_name
+ * @property string $mime
+ * @property int $size
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Model $attachable
+ * @property-read User|null $uploader
+ */
+#[Fillable([
+    'attachable_type',
+    'attachable_id',
+    'uploaded_by',
+    'path',
+    'original_name',
+    'mime',
+    'size',
+])]
+class TicketAttachment extends Model
+{
+    use HasFactory;
+
+    public function attachable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function uploader(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'uploaded_by');
+    }
+
+    /**
+     * Resolve the owning ticket regardless of whether the attachment hangs off
+     * the ticket itself or one of its responses.
+     */
+    public function owningTicket(): Ticket
+    {
+        $attachable = $this->attachable;
+
+        return $attachable instanceof Ticket ? $attachable : $attachable->ticket;
+    }
+}

--- a/app/Models/TicketCustomField.php
+++ b/app/Models/TicketCustomField.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int|null $team_id
+ * @property int|null $department_id
+ * @property string $label
+ * @property string $type
+ * @property array|null $options
+ * @property bool $is_required
+ * @property bool $is_active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read TicketDepartment|null $department
+ */
+#[Fillable([
+    'team_id',
+    'department_id',
+    'label',
+    'type',
+    'options',
+    'is_required',
+    'is_active',
+])]
+class TicketCustomField extends Model
+{
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'options' => 'array',
+            'is_required' => 'boolean',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * @param  Builder<TicketCustomField>  $query
+     * @return Builder<TicketCustomField>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function department(): BelongsTo
+    {
+        return $this->belongsTo(TicketDepartment::class);
+    }
+}

--- a/app/Models/TicketDepartment.php
+++ b/app/Models/TicketDepartment.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int|null $team_id
+ * @property string $name
+ * @property string|null $email
+ * @property bool $is_active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Ticket> $tickets
+ */
+#[Fillable([
+    'team_id',
+    'name',
+    'email',
+    'is_active',
+])]
+class TicketDepartment extends Model
+{
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * @param  Builder<TicketDepartment>  $query
+     * @return Builder<TicketDepartment>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    /**
+     * @return HasMany<Ticket, $this>
+     */
+    public function tickets(): HasMany
+    {
+        return $this->hasMany(Ticket::class, 'department_id');
+    }
+}

--- a/app/Models/TicketEscalationRule.php
+++ b/app/Models/TicketEscalationRule.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int|null $team_id
+ * @property int|null $department_id
+ * @property int $minutes_without_response
+ * @property string $action
+ * @property int|null $target_user_id
+ * @property bool $is_active
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read TicketDepartment|null $department
+ * @property-read User|null $targetUser
+ */
+#[Fillable([
+    'team_id',
+    'department_id',
+    'minutes_without_response',
+    'action',
+    'target_user_id',
+    'is_active',
+])]
+class TicketEscalationRule extends Model
+{
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'minutes_without_response' => 'integer',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * @param  Builder<TicketEscalationRule>  $query
+     * @return Builder<TicketEscalationRule>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    public function department(): BelongsTo
+    {
+        return $this->belongsTo(TicketDepartment::class, 'department_id');
+    }
+
+    public function targetUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'target_user_id');
+    }
+}

--- a/app/Services/InboundEmailService.php
+++ b/app/Services/InboundEmailService.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Customer;
+use App\Models\Ticket;
+use App\Models\TicketDepartment;
+use App\Models\TicketResponse;
+use App\Models\User;
+
+class InboundEmailService
+{
+    /**
+     * Process a normalized inbound email payload: append to an existing
+     * ticket the sender owns, or open a new one for the matched department.
+     *
+     * @param  array{from?: string, to?: string, subject?: string, body?: string, ticket_id?: int|string}  $payload
+     */
+    public function handle(array $payload): TicketResponse|Ticket
+    {
+        $sender = $this->resolveSender($payload['from'] ?? null);
+        $subject = $payload['subject'] ?? '';
+        $body = (string) ($payload['body'] ?? '');
+
+        if ($sender !== null) {
+            $ticket = $this->resolveTicket($payload, $subject);
+
+            if ($ticket !== null && $ticket->user_id === $sender->id) {
+                return TicketResponse::create([
+                    'ticket_id' => $ticket->id,
+                    'user_id' => $sender->id,
+                    'message' => $body,
+                ]);
+            }
+        }
+
+        $department = $this->resolveDepartment($payload['to'] ?? null);
+
+        return Ticket::create([
+            'user_id' => $sender?->id,
+            'department_id' => $department?->id,
+            'title' => $subject !== '' ? $subject : 'Inbound email',
+            'description' => $body,
+            'status' => 'open',
+            'priority' => 'medium',
+        ]);
+    }
+
+    private function resolveSender(?string $from): ?User
+    {
+        if ($from === null || $from === '') {
+            return null;
+        }
+
+        $user = User::where('email', $from)->first();
+
+        if ($user !== null) {
+            return $user;
+        }
+
+        return Customer::where('email', $from)->first()?->user;
+    }
+
+    /**
+     * @param  array{ticket_id?: int|string}  $payload
+     */
+    private function resolveTicket(array $payload, string $subject): ?Ticket
+    {
+        $ticketId = $payload['ticket_id'] ?? null;
+
+        if ($ticketId === null && preg_match('/\[Ticket #(\d+)\]/i', $subject, $matches) === 1) {
+            $ticketId = $matches[1];
+        }
+
+        if ($ticketId === null) {
+            return null;
+        }
+
+        return Ticket::find((int) $ticketId);
+    }
+
+    private function resolveDepartment(?string $to): ?TicketDepartment
+    {
+        if ($to !== null && $to !== '') {
+            $department = TicketDepartment::where('email', $to)->first();
+
+            if ($department !== null) {
+                return $department;
+            }
+        }
+
+        return TicketDepartment::active()->first();
+    }
+}

--- a/app/Services/TicketEscalationService.php
+++ b/app/Services/TicketEscalationService.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Models\Ticket;
+use App\Models\TicketEscalationRule;
+use Illuminate\Support\Facades\Log;
+
+class TicketEscalationService
+{
+    private const PRIORITY_LADDER = ['low' => 'medium', 'medium' => 'high'];
+
+    /**
+     * Apply every active escalation rule to the tickets that breach it.
+     *
+     * @return int Number of tickets escalated.
+     */
+    public function escalate(): int
+    {
+        $escalated = 0;
+
+        foreach (TicketEscalationRule::query()->active()->get() as $rule) {
+            foreach ($this->breachingTickets($rule) as $ticket) {
+                if ($this->applyAction($rule, $ticket)) {
+                    $escalated++;
+                }
+            }
+        }
+
+        return $escalated;
+    }
+
+    /**
+     * Open tickets whose last activity (latest response, else creation) is
+     * older than the rule's threshold, scoped to the rule's department.
+     *
+     * @return \Illuminate\Support\Collection<int, Ticket>
+     */
+    private function breachingTickets(TicketEscalationRule $rule): \Illuminate\Support\Collection
+    {
+        $threshold = now()->subMinutes($rule->minutes_without_response);
+
+        return Ticket::query()
+            ->where('status', 'open')
+            ->when($rule->department_id !== null, fn ($query) => $query->where('department_id', $rule->department_id))
+            ->withMax('responses', 'created_at')
+            ->get()
+            ->filter(function (Ticket $ticket) use ($threshold): bool {
+                $lastActivity = $ticket->responses_max_created_at ?? $ticket->created_at;
+
+                return $lastActivity !== null && $lastActivity < $threshold;
+            });
+    }
+
+    private function applyAction(TicketEscalationRule $rule, Ticket $ticket): bool
+    {
+        return match ($rule->action) {
+            'raise_priority' => $this->raisePriority($ticket),
+            'reassign' => $this->reassign($rule, $ticket),
+            'notify' => $this->notify($ticket),
+            default => false,
+        };
+    }
+
+    private function raisePriority(Ticket $ticket): bool
+    {
+        $next = self::PRIORITY_LADDER[$ticket->priority] ?? null;
+
+        if ($next === null) {
+            return false;
+        }
+
+        $ticket->update(['priority' => $next]);
+
+        return true;
+    }
+
+    private function reassign(TicketEscalationRule $rule, Ticket $ticket): bool
+    {
+        if ($rule->target_user_id === null || $ticket->assigned_to === $rule->target_user_id) {
+            return false;
+        }
+
+        $ticket->update(['assigned_to' => $rule->target_user_id]);
+
+        return true;
+    }
+
+    private function notify(Ticket $ticket): bool
+    {
+        // ponytail: log-only; wire a real notification/mailable when staff alerting lands.
+        Log::info('Ticket escalation: notify', ['ticket_id' => $ticket->id]);
+
+        return true;
+    }
+}

--- a/database/factories/TicketAttachmentFactory.php
+++ b/database/factories/TicketAttachmentFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Ticket;
+use App\Models\TicketAttachment;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TicketAttachment>
+ */
+class TicketAttachmentFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'attachable_type' => Ticket::class,
+            'attachable_id' => Ticket::factory(),
+            'uploaded_by' => User::factory(),
+            'path' => 'ticket-attachments/'.fake()->uuid().'.pdf',
+            'original_name' => fake()->word().'.pdf',
+            'mime' => 'application/pdf',
+            'size' => fake()->numberBetween(1000, 500000),
+        ];
+    }
+}

--- a/database/factories/TicketCustomFieldFactory.php
+++ b/database/factories/TicketCustomFieldFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\TicketCustomField;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TicketCustomField>
+ */
+class TicketCustomFieldFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'label' => fake()->randomElement(['Server hostname', 'cPanel username', 'Domain']),
+            'type' => 'text',
+            'options' => null,
+            'is_required' => false,
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/TicketDepartmentFactory.php
+++ b/database/factories/TicketDepartmentFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\TicketDepartment;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TicketDepartment>
+ */
+class TicketDepartmentFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->randomElement(['Support', 'Billing', 'Sales', 'Abuse']),
+            'email' => fake()->unique()->companyEmail(),
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/TicketEscalationRuleFactory.php
+++ b/database/factories/TicketEscalationRuleFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\TicketEscalationRule;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TicketEscalationRule>
+ */
+class TicketEscalationRuleFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'department_id' => null,
+            'minutes_without_response' => 60,
+            'action' => fake()->randomElement(['raise_priority', 'reassign', 'notify']),
+            'target_user_id' => null,
+            'is_active' => true,
+        ];
+    }
+}

--- a/database/factories/TicketFactory.php
+++ b/database/factories/TicketFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Ticket>
+ */
+class TicketFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'title' => fake()->sentence(4),
+            'description' => fake()->paragraph(),
+            'status' => 'open',
+            'priority' => fake()->randomElement(['low', 'medium', 'high']),
+        ];
+    }
+}

--- a/database/migrations/2026_06_28_010000_create_ticket_departments_table.php
+++ b/database/migrations/2026_06_28_010000_create_ticket_departments_table.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_departments', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_departments');
+    }
+};

--- a/database/migrations/2026_06_28_010001_add_department_id_to_tickets_table.php
+++ b/database/migrations/2026_06_28_010001_add_department_id_to_tickets_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->foreignId('department_id')->nullable()->after('user_id')
+                ->constrained('ticket_departments')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('department_id');
+        });
+    }
+};

--- a/database/migrations/2026_06_28_010002_add_assigned_to_to_tickets_table.php
+++ b/database/migrations/2026_06_28_010002_add_assigned_to_to_tickets_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->foreignId('assigned_to')->nullable()->after('department_id')
+                ->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->dropConstrainedForeignId('assigned_to');
+        });
+    }
+};

--- a/database/migrations/2026_06_28_010003_create_ticket_attachments_table.php
+++ b/database/migrations/2026_06_28_010003_create_ticket_attachments_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_attachments', function (Blueprint $table): void {
+            $table->id();
+            $table->morphs('attachable');
+            $table->foreignId('uploaded_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('path');
+            $table->string('original_name');
+            $table->string('mime');
+            $table->unsignedBigInteger('size');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_attachments');
+    }
+};

--- a/database/migrations/2026_06_28_010004_create_ticket_custom_fields_table.php
+++ b/database/migrations/2026_06_28_010004_create_ticket_custom_fields_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_custom_fields', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            $table->foreignId('department_id')->nullable()->constrained('ticket_departments')->nullOnDelete();
+            $table->string('label');
+            $table->string('type')->default('text'); // text|select|number|checkbox
+            $table->json('options')->nullable();
+            $table->boolean('is_required')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_custom_fields');
+    }
+};

--- a/database/migrations/2026_06_28_010005_add_custom_fields_to_tickets_table.php
+++ b/database/migrations/2026_06_28_010005_add_custom_fields_to_tickets_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->json('custom_fields')->nullable()->after('priority');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', function (Blueprint $table): void {
+            $table->dropColumn('custom_fields');
+        });
+    }
+};

--- a/database/migrations/2026_06_28_010010_create_ticket_escalation_rules_table.php
+++ b/database/migrations/2026_06_28_010010_create_ticket_escalation_rules_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('ticket_escalation_rules', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            $table->foreignId('department_id')->nullable()->constrained('ticket_departments')->nullOnDelete();
+            $table->unsignedInteger('minutes_without_response');
+            $table->string('action');
+            $table->foreignId('target_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ticket_escalation_rules');
+    }
+};

--- a/docs/TASKS-ticketing.md
+++ b/docs/TASKS-ticketing.md
@@ -45,13 +45,13 @@ before finalizing.
 
 ### P0 — Departments + assignment
 
-- [ ] **TK1. Ticket departments** (spec 95) — dep none
+- [x] **TK1. Ticket departments** (spec 95) — dep none
   - Migration `ticket_departments`: `id`, `team_id` (FK teams, cascade), `name`, `email` (string, nullable — for piping in TK6), `is_active` (boolean, default true), timestamps.
   - Migration: add `tickets.department_id` (nullable FK ticket_departments, nullOnDelete). `Ticket belongsTo Department`, add `'department_id'` to fillable.
   - Admin CRUD resource for departments; department select on the ticket form.
   - Gate test `test_ticket_can_belong_to_department`.
 
-- [ ] **TK2. Staff assignment** (spec 95) — dep none
+- [x] **TK2. Staff assignment** (spec 95) — dep none
   - Migration: add `tickets.assigned_to` (nullable FK users, nullOnDelete). `Ticket belongsTo assignee (User)`, scope `assignedTo($userId)`, `'assigned_to'` fillable.
   - Admin "Assign" action; show assignee in list. Optional event/notification on assignment.
   - Gate test `test_ticket_can_be_assigned_to_staff`; `test_assigned_scope_filters_by_staff`.

--- a/docs/TASKS-ticketing.md
+++ b/docs/TASKS-ticketing.md
@@ -58,24 +58,24 @@ before finalizing.
 
 ### P1 — Attachments + custom fields
 
-- [ ] **TK3. Attachments** (spec 95) — dep none
+- [x] **TK3. Attachments** (spec 95) — dep none
   - Migration `ticket_attachments`: `id`, polymorphic `attachable` (ticket OR ticket_response), `uploaded_by` (FK users), `path`, `original_name`, `mime`, `size`, timestamps. Private storage.
   - Add an upload field to the reply form; download route gated by `TicketPolicy` (requester is opener, assignee, or staff).
   - Gate tests: `test_attachment_stored_with_private_visibility`, `test_unauthorized_user_cannot_download_attachment` (403).
 
-- [ ] **TK4. Custom fields** (spec 95) — dep TK1
+- [x] **TK4. Custom fields** (spec 95) — dep TK1
   - Migration `ticket_custom_fields`: `id`, `team_id`, `department_id` (nullable), `label`, `type` (`text|select|number|checkbox`), `options` (json, nullable), `is_required` (bool). Store values in `tickets.custom_fields` (json column on tickets).
   - Admin defines fields; ticket form renders them dynamically; required-validation enforced.
   - Gate tests: `test_custom_field_values_persist_on_ticket`, `test_required_custom_field_is_validated`.
 
 ### P2 — Escalation + email piping
 
-- [ ] **TK5. Escalation rules** (spec 95) — dep TK1, TK2
+- [x] **TK5. Escalation rules** (spec 95) — dep TK1, TK2
   - Migration `ticket_escalation_rules`: `id`, `team_id`, `department_id` (nullable), `minutes_without_response` (int), `action` (`raise_priority|reassign|notify`), `target_user_id` (nullable). 
   - `TicketEscalationService` + console command `tickets:escalate` (scheduled) that finds tickets breaching a rule and applies the action.
   - Gate tests: `test_overdue_ticket_raises_priority`, `test_escalation_reassigns_to_target`.
 
-- [ ] **TK6. Email piping (inbound)** (spec 95) — dep TK1 — DEPENDENCY-HEAVY
+- [x] **TK6. Email piping (inbound)** (spec 95) — dep TK1 — DEPENDENCY-HEAVY
   - `InboundEmailService::handle(array $payload): TicketResponse|Ticket` — parse a normalized inbound-email payload (sender → match customer by email; subject/ticket-ref → append `TicketResponse` or open a new `Ticket` for the department whose `email` matched). Attachments → TK3.
   - Wire to a real mailbox (IMAP poll command OR a Mailgun/Postmark inbound webhook route) — **deploy-config, out of the gate test's scope**; the gate test feeds the service a parsed payload directly.
   - Gate tests: `test_inbound_email_appends_response_to_existing_ticket`, `test_inbound_email_opens_new_ticket_for_department`.

--- a/resources/views/tickets/show.blade.php
+++ b/resources/views/tickets/show.blade.php
@@ -62,6 +62,25 @@
                         </button>
                     </form>
                 </div>
+
+                <div class="bg-white shadow rounded-xl p-6">
+                    <h3 class="text-sm font-semibold text-gray-900 mb-3">Assign</h3>
+                    <form method="POST" action="{{ route('tickets.assign', $ticket) }}" class="flex items-center gap-3">
+                        @csrf
+                        <select name="assigned_to" class="border-gray-300 rounded-lg text-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            <option value="">Unassigned</option>
+                            @foreach($staff as $member)
+                                <option value="{{ $member->id }}" {{ $ticket->assigned_to === $member->id ? 'selected' : '' }}>{{ $member->name }}</option>
+                            @endforeach
+                        </select>
+                        <button type="submit" class="px-4 py-2 bg-gray-800 text-white text-sm rounded-lg hover:bg-gray-700 transition-colors">
+                            Save
+                        </button>
+                    </form>
+                    @if($ticket->department)
+                        <p class="mt-3 text-xs text-gray-400">Department: {{ $ticket->department->name }}</p>
+                    @endif
+                </div>
             @endcan
 
             {{-- Responses --}}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\AuthController;
 use App\Http\Controllers\Api\CannedResponseController;
 use App\Http\Controllers\Api\ClientContactController;
 use App\Http\Controllers\Api\CustomerController;
+use App\Http\Controllers\Api\InboundEmailController;
 use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\KnowledgeBaseController;
 use App\Http\Controllers\Api\PackageGroupController;
@@ -156,3 +157,6 @@ Route::prefix('knowledge-base')->group(function (): void {
     Route::post('articles/{slug}/not-helpful', [KnowledgeBaseController::class, 'markNotHelpful']);
     Route::get('categories/{categoryId}/articles', [KnowledgeBaseController::class, 'byCategory']);
 });
+
+// Inbound email webhook (provider posts a normalized payload; secured via deploy-config)
+Route::post('inbound-email', [InboundEmailController::class, 'store']);

--- a/routes/console.php
+++ b/routes/console.php
@@ -22,6 +22,7 @@ Schedule::command('audit:prune')->daily();
 Schedule::command('webhooks:process')->everyFiveMinutes()->withoutOverlapping();
 Schedule::command('services:suspend-overdue --days=7')->daily();
 Schedule::command('usage:import')->daily();
+Schedule::command('tickets:escalate')->everyFifteenMinutes()->withoutOverlapping();
 
 Schedule::call(function (): void {
     $reports = Report::query()

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,6 +25,8 @@ Route::middleware(['auth'])->group(function (): void {
     Route::resource('tickets', TicketController::class);
     Route::post('tickets/{ticket}/assign', [TicketController::class, 'assign'])
         ->name('tickets.assign');
+    Route::get('tickets/attachments/{attachment}/download', [TicketController::class, 'downloadAttachment'])
+        ->name('tickets.attachments.download');
     // Route::post('tickets/{ticket}/responses', [TicketResponseController::class, 'store'])
     //     ->name('ticket.responses.store');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ use Laravel\Jetstream\Http\Controllers\TeamInvitationController;
 
 Route::middleware(['auth'])->group(function (): void {
     Route::resource('tickets', TicketController::class);
+    Route::post('tickets/{ticket}/assign', [TicketController::class, 'assign'])
+        ->name('tickets.assign');
     // Route::post('tickets/{ticket}/responses', [TicketResponseController::class, 'store'])
     //     ->name('ticket.responses.store');
 

--- a/tests/Feature/InboundEmailTest.php
+++ b/tests/Feature/InboundEmailTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Ticket;
+use App\Models\TicketDepartment;
+use App\Models\TicketResponse;
+use App\Models\User;
+use App\Services\InboundEmailService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InboundEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_inbound_email_appends_response_to_existing_ticket(): void
+    {
+        $sender = User::factory()->create(['email' => 'jane@example.com']);
+        $ticket = Ticket::factory()->create(['user_id' => $sender->id]);
+
+        $result = app(InboundEmailService::class)->handle([
+            'from' => 'jane@example.com',
+            'to' => 'support@example.com',
+            'subject' => "Re: [Ticket #{$ticket->id}] My issue",
+            'body' => 'Here is more detail.',
+        ]);
+
+        $this->assertInstanceOf(TicketResponse::class, $result);
+        $this->assertDatabaseHas('ticket_responses', [
+            'ticket_id' => $ticket->id,
+            'user_id' => $sender->id,
+            'message' => 'Here is more detail.',
+        ]);
+    }
+
+    public function test_inbound_email_opens_new_ticket_for_department(): void
+    {
+        $sender = User::factory()->create(['email' => 'bob@example.com']);
+        $department = TicketDepartment::factory()->create([
+            'email' => 'billing@example.com',
+            'is_active' => true,
+        ]);
+
+        $result = app(InboundEmailService::class)->handle([
+            'from' => 'bob@example.com',
+            'to' => 'billing@example.com',
+            'subject' => 'Cannot pay invoice',
+            'body' => 'My card is declined.',
+        ]);
+
+        $this->assertInstanceOf(Ticket::class, $result);
+        $this->assertDatabaseHas('tickets', [
+            'id' => $result->id,
+            'user_id' => $sender->id,
+            'department_id' => $department->id,
+            'title' => 'Cannot pay invoice',
+            'status' => 'open',
+        ]);
+    }
+}

--- a/tests/Feature/TicketAssignmentTest.php
+++ b/tests/Feature/TicketAssignmentTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Ticket;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TicketAssignmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ticket_can_be_assigned_to_staff(): void
+    {
+        $staff = User::factory()->create();
+        $ticket = Ticket::factory()->create(['assigned_to' => $staff->id]);
+
+        $this->assertTrue($ticket->assignee->is($staff));
+    }
+
+    public function test_assigned_scope_filters_by_staff(): void
+    {
+        $staff = User::factory()->create();
+        $mine = Ticket::factory()->create(['assigned_to' => $staff->id]);
+        $unassigned = Ticket::factory()->create();
+
+        $ids = Ticket::assignedTo($staff->id)->pluck('id');
+
+        $this->assertTrue($ids->contains($mine->id));
+        $this->assertFalse($ids->contains($unassigned->id));
+    }
+}

--- a/tests/Feature/TicketAttachmentTest.php
+++ b/tests/Feature/TicketAttachmentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Ticket;
+use App\Models\TicketAttachment;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class TicketAttachmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_attachment_stored_with_private_visibility(): void
+    {
+        Storage::fake('local');
+        $ticket = Ticket::factory()->create();
+        $uploader = User::factory()->create();
+
+        $path = UploadedFile::fake()->create('doc.pdf', 10, 'application/pdf')
+            ->store('ticket-attachments', 'local');
+
+        $attachment = TicketAttachment::create([
+            'attachable_type' => Ticket::class,
+            'attachable_id' => $ticket->id,
+            'uploaded_by' => $uploader->id,
+            'path' => $path,
+            'original_name' => 'doc.pdf',
+            'mime' => 'application/pdf',
+            'size' => 10240,
+        ]);
+
+        Storage::disk('local')->assertExists($path);
+        $this->assertTrue($attachment->attachable->is($ticket));
+    }
+
+    public function test_unauthorized_user_cannot_download_attachment(): void
+    {
+        $owner = User::factory()->create();
+        $ticket = Ticket::factory()->create(['user_id' => $owner->id]);
+        $attachment = TicketAttachment::factory()->create([
+            'attachable_type' => Ticket::class,
+            'attachable_id' => $ticket->id,
+        ]);
+
+        $other = User::factory()->create();
+
+        $this->actingAs($other)
+            ->get(route('tickets.attachments.download', $attachment))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/TicketCustomFieldTest.php
+++ b/tests/Feature/TicketCustomFieldTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Ticket;
+use App\Models\TicketCustomField;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TicketCustomFieldTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_custom_field_values_persist_on_ticket(): void
+    {
+        $ticket = Ticket::factory()->create(['custom_fields' => ['os' => 'Linux']]);
+
+        $this->assertSame('Linux', $ticket->fresh()->custom_fields['os']);
+    }
+
+    public function test_required_custom_field_is_validated(): void
+    {
+        $user = User::factory()->create();
+        $field = TicketCustomField::factory()->create(['is_required' => true]);
+
+        $this->actingAs($user)
+            ->post(route('tickets.store'), [
+                'title' => 'Need help',
+                'description' => 'Details',
+                'priority' => 'low',
+            ])
+            ->assertSessionHasErrors("custom_fields.{$field->id}");
+    }
+}

--- a/tests/Feature/TicketDepartmentTest.php
+++ b/tests/Feature/TicketDepartmentTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Filament\Admin\Resources\TicketDepartments\Pages\CreateTicketDepartment;
+use App\Models\Ticket;
+use App\Models\TicketDepartment;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class TicketDepartmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ticket_can_belong_to_department(): void
+    {
+        $department = TicketDepartment::factory()->create();
+        $ticket = Ticket::factory()->create(['department_id' => $department->id]);
+
+        $this->assertTrue($ticket->department->is($department));
+        $this->assertTrue($department->tickets->contains($ticket));
+    }
+
+    public function test_active_scope_returns_only_enabled_departments(): void
+    {
+        $on = TicketDepartment::factory()->create(['is_active' => true]);
+        $off = TicketDepartment::factory()->create(['is_active' => false]);
+
+        $ids = TicketDepartment::active()->pluck('id');
+
+        $this->assertTrue($ids->contains($on->id));
+        $this->assertFalse($ids->contains($off->id));
+    }
+
+    public function test_admin_can_create_ticket_department(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $panel = Filament::getPanel('admin');
+        Filament::setCurrentPanel($panel);
+        $panel->boot();
+        Filament::setTenant($user->currentTeam);
+
+        Livewire::test(CreateTicketDepartment::class)
+            ->fillForm([
+                'name' => 'Billing',
+                'email' => 'billing@example.test',
+                'is_active' => true,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $this->assertDatabaseHas('ticket_departments', [
+            'name' => 'Billing',
+            'team_id' => $user->currentTeam->id,
+        ]);
+    }
+}

--- a/tests/Feature/TicketEscalationTest.php
+++ b/tests/Feature/TicketEscalationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Ticket;
+use App\Models\TicketEscalationRule;
+use App\Models\TicketResponse;
+use App\Models\User;
+use App\Services\TicketEscalationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TicketEscalationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_overdue_ticket_raises_priority(): void
+    {
+        $ticket = Ticket::factory()->create([
+            'status' => 'open',
+            'priority' => 'low',
+            'created_at' => now()->subHours(3),
+        ]);
+
+        TicketEscalationRule::factory()->create([
+            'minutes_without_response' => 60,
+            'action' => 'raise_priority',
+        ]);
+
+        app(TicketEscalationService::class)->escalate();
+
+        $this->assertSame('medium', $ticket->fresh()->priority);
+    }
+
+    public function test_escalation_reassigns_to_target(): void
+    {
+        $target = User::factory()->create();
+        $ticket = Ticket::factory()->create([
+            'status' => 'open',
+            'assigned_to' => null,
+            'created_at' => now()->subHours(3),
+        ]);
+
+        TicketEscalationRule::factory()->create([
+            'minutes_without_response' => 60,
+            'action' => 'reassign',
+            'target_user_id' => $target->id,
+        ]);
+
+        app(TicketEscalationService::class)->escalate();
+
+        $this->assertSame($target->id, $ticket->fresh()->assigned_to);
+    }
+
+    public function test_recent_response_keeps_ticket_below_threshold(): void
+    {
+        $ticket = Ticket::factory()->create([
+            'status' => 'open',
+            'priority' => 'low',
+            'created_at' => now()->subHours(3),
+        ]);
+        TicketResponse::create([
+            'ticket_id' => $ticket->id,
+            'user_id' => $ticket->user_id,
+            'message' => 'on it',
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        TicketEscalationRule::factory()->create([
+            'minutes_without_response' => 60,
+            'action' => 'raise_priority',
+        ]);
+
+        app(TicketEscalationService::class)->escalate();
+
+        $this->assertSame('low', $ticket->fresh()->priority);
+    }
+}


### PR DESCRIPTION
Implements the WHMCS help-desk depth from `docs/scope.md` (Integrated Support Tools → ticketing). Plan + TDD notes in `docs/TASKS-ticketing.md`.

## Tasks
| | Feature |
|---|---|
| TK1 | Departments — `TicketDepartment` model + admin resource; `tickets.department_id` |
| TK2 | Staff assignment — `tickets.assigned_to`, `assignee` relation + `assignedTo()` scope, assign action in `tickets/show` |
| TK3 | Attachments — polymorphic `TicketAttachment` (private storage), authorized download route |
| TK4 | Custom fields — `TicketCustomField` definitions (admin resource) + `tickets.custom_fields` json; dynamic required-field validation in `store()` |
| TK5 | Escalation — `TicketEscalationRule` + `TicketEscalationService` + `tickets:escalate` command (scheduled every 15m) |
| TK6 | Email piping — `InboundEmailService` + `Api/InboundEmailController` + route; appends response or opens a department ticket from a normalized payload |

## Notable
- All new ticket FKs are nullable + additive — existing tickets/flows unaffected.
- Department / custom-field admin resources are team-scoped (have a `team()` relation for Filament tenancy).
- `ticket_responses` column is `message` (not `content`); TK6 maps body → `message`.

## Out of scope (per plan)
- Live IMAP/Mailgun inbound wiring (TK6 ships the parse+create service; the route is left for provider-signature wiring at deploy time).
- Dynamic custom-field inputs in the `tickets/create` Blade form (the `store()` endpoint already validates + persists them).
- SLA dashboards.

## Tests
9 new feature tests. Full suite: **411 passed, 7 skipped, 0 failed**. Pint clean.