### PR TITLE
Software licensing addon (keys, validation, instances, reissue, portal, SDK)

### DIFF
--- a/app/Enums/LicenseStatus.php
+++ b/app/Enums/LicenseStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum LicenseStatus: string implements HasColor, HasLabel
+{
+    case Active = 'active';
+    case Suspended = 'suspended';
+    case ReissuePending = 'reissue_pending';
+    case Expired = 'expired';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::Active => 'Active',
+            self::Suspended => 'Suspended',
+            self::ReissuePending => 'Reissue pending',
+            self::Expired => 'Expired',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::Active => 'success',
+            self::Suspended => 'warning',
+            self::ReissuePending => 'info',
+            self::Expired => 'danger',
+        };
+    }
+}

--- a/app/Filament/Admin/Resources/Licenses/LicenseResource.php
+++ b/app/Filament/Admin/Resources/Licenses/LicenseResource.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\Licenses;
+
+use App\Filament\Admin\Resources\Licenses\Pages\CreateLicense;
+use App\Filament\Admin\Resources\Licenses\Pages\EditLicense;
+use App\Filament\Admin\Resources\Licenses\Pages\ListLicenses;
+use App\Filament\Admin\Resources\Licenses\Schemas\LicenseForm;
+use App\Filament\Admin\Resources\Licenses\Tables\LicensesTable;
+use App\Models\License;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+use Override;
+use UnitEnum;
+
+class LicenseResource extends Resource
+{
+    #[Override]
+    protected static ?string $model = License::class;
+
+    #[Override]
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedKey;
+
+    #[Override]
+    protected static string|UnitEnum|null $navigationGroup = 'Licensing';
+
+    #[Override]
+    public static function form(Schema $schema): Schema
+    {
+        return LicenseForm::configure($schema);
+    }
+
+    #[Override]
+    public static function table(Table $table): Table
+    {
+        return LicensesTable::configure($table);
+    }
+
+    #[Override]
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    #[Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListLicenses::route('/'),
+            'create' => CreateLicense::route('/create'),
+            'edit' => EditLicense::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Licenses/Pages/CreateLicense.php
+++ b/app/Filament/Admin/Resources/Licenses/Pages/CreateLicense.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\Licenses\Pages;
+
+use App\Filament\Admin\Resources\Licenses\LicenseResource;
+use App\Services\LicenseService;
+use Filament\Resources\Pages\CreateRecord;
+use Override;
+
+class CreateLicense extends CreateRecord
+{
+    #[Override]
+    protected static string $resource = LicenseResource::class;
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    #[Override]
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if (empty($data['license_key'])) {
+            $data['license_key'] = app(LicenseService::class)->generate();
+        }
+
+        return $data;
+    }
+}

--- a/app/Filament/Admin/Resources/Licenses/Pages/EditLicense.php
+++ b/app/Filament/Admin/Resources/Licenses/Pages/EditLicense.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\Licenses\Pages;
+
+use App\Filament\Admin\Resources\Licenses\LicenseResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Override;
+
+class EditLicense extends EditRecord
+{
+    #[Override]
+    protected static string $resource = LicenseResource::class;
+
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Licenses/Pages/ListLicenses.php
+++ b/app/Filament/Admin/Resources/Licenses/Pages/ListLicenses.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\Licenses\Pages;
+
+use App\Filament\Admin\Resources\Licenses\LicenseResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Override;
+
+class ListLicenses extends ListRecords
+{
+    #[Override]
+    protected static string $resource = LicenseResource::class;
+
+    #[Override]
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/Licenses/Schemas/LicenseForm.php
+++ b/app/Filament/Admin/Resources/Licenses/Schemas/LicenseForm.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\Licenses\Schemas;
+
+use App\Enums\LicenseStatus;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Schema;
+
+class LicenseForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components(
+                [
+                    Select::make('customer_id')
+                        ->relationship('customer', 'name')
+                        ->searchable()
+                        ->preload()
+                        ->required(),
+                    Select::make('product_service_id')
+                        ->relationship('productService', 'name')
+                        ->searchable()
+                        ->preload(),
+                    Select::make('status')
+                        ->options(LicenseStatus::class)
+                        ->default(LicenseStatus::Active)
+                        ->required(),
+                    TextInput::make('max_instances')
+                        ->integer()
+                        ->default(1)
+                        ->required(),
+                    DatePicker::make('valid_until'),
+                    Textarea::make('notes')
+                        ->columnSpanFull(),
+                ]
+            );
+    }
+}

--- a/app/Filament/Admin/Resources/Licenses/Tables/LicensesTable.php
+++ b/app/Filament/Admin/Resources/Licenses/Tables/LicensesTable.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\Licenses\Tables;
+
+use App\Enums\LicenseStatus;
+use App\Models\License;
+use App\Services\LicenseService;
+use Filament\Actions\Action;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Throwable;
+
+class LicensesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    TextColumn::make('license_key')
+                        ->searchable()
+                        ->copyable(),
+                    TextColumn::make('customer.name')
+                        ->searchable(),
+                    TextColumn::make('status')
+                        ->badge(),
+                    TextColumn::make('max_instances'),
+                    TextColumn::make('valid_until')
+                        ->date(),
+                ]
+            )
+            ->filters(
+                [
+                    //
+                ]
+            )
+            ->recordActions(
+                [
+                    EditAction::make(),
+                    Action::make('reissue')
+                        ->icon(Heroicon::OutlinedArrowPath)
+                        ->requiresConfirmation()
+                        ->action(function (License $record): void {
+                            try {
+                                app(LicenseService::class)->reissue($record, auth()->id());
+                            } catch (Throwable $e) {
+                                Notification::make()
+                                    ->title($e->getMessage())
+                                    ->danger()
+                                    ->send();
+                            }
+                        }),
+                    Action::make('toggleSuspend')
+                        ->label(fn (License $record): string => $record->status === LicenseStatus::Suspended ? 'Unsuspend' : 'Suspend')
+                        ->icon(Heroicon::OutlinedPower)
+                        ->requiresConfirmation()
+                        ->action(fn (License $record) => $record->update([
+                            'status' => $record->status === LicenseStatus::Suspended
+                                ? LicenseStatus::Active
+                                : LicenseStatus::Suspended,
+                        ])),
+                    DeleteAction::make(),
+                ]
+            )
+            ->toolbarActions(
+                [
+                    BulkActionGroup::make(
+                        [
+                            DeleteBulkAction::make(),
+                        ]
+                    ),
+                ]
+            );
+    }
+}

--- a/app/Filament/Client/Resources/LicenseResource.php
+++ b/app/Filament/Client/Resources/LicenseResource.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace App\Filament\Client\Resources;
+
+use App\Filament\Client\Resources\LicenseResource\Pages\ListLicenses;
+use App\Filament\Client\Resources\LicenseResource\Pages\ViewLicense;
+use App\Models\License;
+use App\Services\LicenseService;
+use BackedEnum;
+use Filament\Actions\Action;
+use Filament\Actions\ViewAction;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Override;
+
+class LicenseResource extends Resource
+{
+    #[Override]
+    protected static ?string $model = License::class;
+
+    #[Override]
+    protected static string|BackedEnum|null $navigationIcon = 'heroicon-o-key';
+
+    #[Override]
+    protected static ?string $navigationLabel = 'Licenses';
+
+    #[Override]
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    #[Override]
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->components(
+                [
+                    Section::make()
+                        ->schema(
+                            [
+                                TextEntry::make('license_key')
+                                    ->label('License Key')
+                                    ->copyable(),
+                                TextEntry::make('status')
+                                    ->badge(),
+                                TextEntry::make('max_instances')
+                                    ->label('Max Instances'),
+                                TextEntry::make('valid_until')
+                                    ->date()
+                                    ->placeholder('No expiry'),
+                            ]
+                        ),
+                ]
+            );
+    }
+
+    #[Override]
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns(
+                [
+                    TextColumn::make('license_key')
+                        ->label('License Key')
+                        ->searchable()
+                        ->copyable(),
+                    TextColumn::make('status')
+                        ->badge(),
+                    TextColumn::make('max_instances')
+                        ->label('Max Instances')
+                        ->sortable(),
+                    TextColumn::make('valid_until')
+                        ->date()
+                        ->placeholder('No expiry')
+                        ->sortable(),
+                ]
+            )
+            ->recordActions(
+                [
+                    ViewAction::make(),
+                    Action::make('reissue')
+                        ->icon('heroicon-o-arrow-path')
+                        ->requiresConfirmation()
+                        ->action(
+                            fn (License $record) => app(LicenseService::class)->reissue($record)
+                        ),
+                ]
+            )
+            ->defaultSort(
+                'created_at',
+                'desc'
+            );
+    }
+
+    #[Override]
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListLicenses::route('/'),
+            'view' => ViewLicense::route('/{record}'),
+        ];
+    }
+
+    #[Override]
+    public static function getEloquentQuery(): Builder
+    {
+        // Licenses belong to a Customer (no client_id column exists). The client
+        // panel authenticates a User, so scope to licenses of the Customer whose
+        // email matches the logged-in user.
+        return parent::getEloquentQuery()->whereHas(
+            'customer',
+            fn (Builder $query) => $query->where('email', auth()->user()->email)
+        );
+    }
+}

--- a/app/Filament/Client/Resources/LicenseResource/Pages/ListLicenses.php
+++ b/app/Filament/Client/Resources/LicenseResource/Pages/ListLicenses.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Client\Resources\LicenseResource\Pages;
+
+use App\Filament\Client\Resources\LicenseResource;
+use Filament\Resources\Pages\ListRecords;
+use Override;
+
+class ListLicenses extends ListRecords
+{
+    #[Override]
+    protected static string $resource = LicenseResource::class;
+}

--- a/app/Filament/Client/Resources/LicenseResource/Pages/ViewLicense.php
+++ b/app/Filament/Client/Resources/LicenseResource/Pages/ViewLicense.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Client\Resources\LicenseResource\Pages;
+
+use App\Filament\Client\Resources\LicenseResource;
+use Filament\Resources\Pages\ViewRecord;
+use Override;
+
+class ViewLicense extends ViewRecord
+{
+    #[Override]
+    protected static string $resource = LicenseResource::class;
+}

--- a/app/Http/Controllers/Api/LicenseDownloadController.php
+++ b/app/Http/Controllers/Api/LicenseDownloadController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\LicenseService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class LicenseDownloadController extends Controller
+{
+    public function __construct(private readonly LicenseService $licenses) {}
+
+    /**
+     * Serve the protected product download only to a validly-licensed instance.
+     */
+    public function download(Request $request): StreamedResponse
+    {
+        $data = $request->validate([
+            'license_key' => ['required', 'string'],
+            'identifier' => ['required', 'string'],
+        ]);
+
+        $result = $this->licenses->validate($data['license_key'], [
+            'identifier' => $data['identifier'],
+            'ip_address' => $request->ip(),
+        ]);
+
+        abort_unless($result['valid'], 403, 'A valid license is required to download.');
+
+        // ponytail: single protected artifact for now; key the path off the
+        // license's product when per-product downloads are needed.
+        return Storage::disk('local')->download('protected/release.zip', 'release.zip');
+    }
+}

--- a/app/Http/Controllers/Api/LicenseValidationController.php
+++ b/app/Http/Controllers/Api/LicenseValidationController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Services\LicenseService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class LicenseValidationController extends Controller
+{
+    public function __construct(private readonly LicenseService $licenses) {}
+
+    public function validateLicense(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'license_key' => ['required', 'string'],
+            'identifier' => ['required', 'string'],
+            'ip_address' => ['nullable', 'string'],
+        ]);
+
+        $result = $this->licenses->validate($data['license_key'], [
+            'identifier' => $data['identifier'],
+            'ip_address' => $data['ip_address'] ?? $request->ip(),
+        ]);
+
+        return response()->json($result);
+    }
+}

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Enums\LicenseStatus;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -29,7 +30,7 @@ use Illuminate\Support\Carbon;
  * @property-read Team|null $team
  * @property-read Customer $customer
  * @property-read Products_Service|null $productService
- * @property-read \Illuminate\Database\Eloquent\Collection<int, LicenseInstance> $instances
+ * @property-read Collection<int, LicenseInstance> $instances
  */
 #[Fillable([
     'team_id',

--- a/app/Models/License.php
+++ b/app/Models/License.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\LicenseStatus;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int|null $team_id
+ * @property int $customer_id
+ * @property int|null $product_service_id
+ * @property string $license_key
+ * @property LicenseStatus $status
+ * @property int $max_instances
+ * @property Carbon|null $valid_until
+ * @property string|null $notes
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Team|null $team
+ * @property-read Customer $customer
+ * @property-read Products_Service|null $productService
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, LicenseInstance> $instances
+ */
+#[Fillable([
+    'team_id',
+    'customer_id',
+    'product_service_id',
+    'license_key',
+    'status',
+    'max_instances',
+    'valid_until',
+    'notes',
+])]
+class License extends Model
+{
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => LicenseStatus::class,
+            'valid_until' => 'date',
+        ];
+    }
+
+    /**
+     * @param  Builder<License>  $query
+     * @return Builder<License>
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', LicenseStatus::Active->value);
+    }
+
+    public function isUsable(): bool
+    {
+        return $this->status === LicenseStatus::Active
+            && ($this->valid_until === null || $this->valid_until->isFuture());
+    }
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(Customer::class);
+    }
+
+    public function productService(): BelongsTo
+    {
+        return $this->belongsTo(Products_Service::class, 'product_service_id');
+    }
+
+    /**
+     * @return HasMany<LicenseInstance, $this>
+     */
+    public function instances(): HasMany
+    {
+        return $this->hasMany(LicenseInstance::class);
+    }
+
+    /**
+     * @return HasMany<LicenseReissue, $this>
+     */
+    public function reissues(): HasMany
+    {
+        return $this->hasMany(LicenseReissue::class);
+    }
+}

--- a/app/Models/LicenseInstance.php
+++ b/app/Models/LicenseInstance.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $license_id
+ * @property string $identifier
+ * @property string|null $ip_address
+ * @property Carbon|null $last_validated_at
+ * @property string|null $local_key
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read License $license
+ */
+#[Fillable([
+    'license_id',
+    'identifier',
+    'ip_address',
+    'last_validated_at',
+    'local_key',
+])]
+class LicenseInstance extends Model
+{
+    use HasFactory;
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'last_validated_at' => 'datetime',
+        ];
+    }
+
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(License::class);
+    }
+}

--- a/app/Models/LicenseReissue.php
+++ b/app/Models/LicenseReissue.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $license_id
+ * @property int|null $reissued_by
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read License $license
+ */
+#[Fillable([
+    'license_id',
+    'reissued_by',
+])]
+class LicenseReissue extends Model
+{
+    public function license(): BelongsTo
+    {
+        return $this->belongsTo(License::class);
+    }
+}

--- a/app/Services/LicenseService.php
+++ b/app/Services/LicenseService.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\LicenseStatus;
+use App\Models\License;
+use App\Models\LicenseInstance;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class LicenseService
+{
+    /**
+     * Reissue a license — clear its registered instances so it can be activated
+     * on a fresh install. Abuse-guarded: too many reissues within the window
+     * are rejected.
+     */
+    public function reissue(License $license, ?int $reissuedBy = null): void
+    {
+        $limit = (int) config('licensing.reissue_limit', 3);
+        $windowHours = (int) config('licensing.reissue_window_hours', 24);
+
+        $recent = $license->reissues()
+            ->where('created_at', '>=', now()->subHours($windowHours))
+            ->count();
+
+        if ($recent >= $limit) {
+            throw new RuntimeException('License reissue limit reached; try again later.');
+        }
+
+        $license->instances()->delete();
+        $license->update(['status' => LicenseStatus::Active]);
+        $license->reissues()->create(['reissued_by' => $reissuedBy]);
+    }
+
+    /**
+     * Generate a unique, human-readable license key: PREFIX-XXXXX-XXXXX-...
+     */
+    public function generate(string $prefix = 'LIC', int $segments = 4, int $segmentLength = 5): string
+    {
+        do {
+            $parts = [];
+            for ($i = 0; $i < $segments; $i++) {
+                $parts[] = strtoupper(Str::random($segmentLength));
+            }
+            $key = $prefix.'-'.implode('-', $parts);
+        } while (License::withTrashed()->where('license_key', $key)->exists());
+
+        return $key;
+    }
+
+    /**
+     * Validate a license key for a calling instance. Registers/refreshes the
+     * instance (enforcing max_instances) and returns the verdict + a signed
+     * offline key the SDK can cache.
+     *
+     * @param  array{identifier?: string, ip_address?: string}  $instance
+     * @return array{valid: bool, status: string, reason?: string, data?: array{local_key: string}}
+     */
+    public function validate(string $licenseKey, array $instance): array
+    {
+        $identifier = $instance['identifier'] ?? '';
+
+        $license = License::where('license_key', $licenseKey)->first();
+
+        if ($license === null || ! $license->isUsable()) {
+            return [
+                'valid' => false,
+                'status' => $license?->status->value ?? 'unknown',
+            ];
+        }
+
+        $existing = $license->instances()->where('identifier', $identifier)->first();
+
+        if ($existing === null && $license->instances()->count() >= $license->max_instances) {
+            return [
+                'valid' => false,
+                'status' => $license->status->value,
+                'reason' => 'instance_limit_reached',
+            ];
+        }
+
+        $localKey = $this->localKey($licenseKey, $identifier);
+
+        LicenseInstance::updateOrCreate(
+            ['license_id' => $license->id, 'identifier' => $identifier],
+            [
+                'ip_address' => $instance['ip_address'] ?? null,
+                'last_validated_at' => now(),
+                'local_key' => $localKey,
+            ],
+        );
+
+        return [
+            'valid' => true,
+            'status' => $license->status->value,
+            'data' => ['local_key' => $localKey],
+        ];
+    }
+
+    /**
+     * Verify a cached offline key — lets the SDK keep working while the platform
+     * is unreachable. ponytail: deterministic HMAC, no TTL; add expiry+rotation
+     * if offline keys must age out.
+     */
+    public function verifyLocalKey(string $licenseKey, string $identifier, string $localKey): bool
+    {
+        return hash_equals($this->localKey($licenseKey, $identifier), $localKey);
+    }
+
+    private function localKey(string $licenseKey, string $identifier): string
+    {
+        return hash_hmac('sha256', $licenseKey.'|'.$identifier, (string) config('app.key'));
+    }
+}

--- a/database/factories/LicenseFactory.php
+++ b/database/factories/LicenseFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\LicenseStatus;
+use App\Models\Customer;
+use App\Models\License;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<License>
+ */
+class LicenseFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'license_key' => 'LIC-'.strtoupper(Str::random(5)).'-'.strtoupper(Str::random(5)).'-'.strtoupper(Str::random(5)).'-'.strtoupper(Str::random(5)),
+            'status' => LicenseStatus::Active,
+            'max_instances' => 1,
+        ];
+    }
+}

--- a/database/factories/LicenseInstanceFactory.php
+++ b/database/factories/LicenseInstanceFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\License;
+use App\Models\LicenseInstance;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<LicenseInstance>
+ */
+class LicenseInstanceFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'license_id' => License::factory(),
+            'identifier' => fake()->domainName(),
+            'ip_address' => fake()->ipv4(),
+            'last_validated_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_06_28_020000_create_licenses_table.php
+++ b/database/migrations/2026_06_28_020000_create_licenses_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('licenses', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('team_id')->nullable()->constrained('teams')->nullOnDelete();
+            $table->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
+            $table->foreignId('product_service_id')->nullable()->constrained('products_services')->nullOnDelete();
+            $table->string('license_key')->unique();
+            $table->string('status')->default('active');
+            $table->unsignedInteger('max_instances')->default(1);
+            $table->date('valid_until')->nullable();
+            $table->text('notes')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('licenses');
+    }
+};

--- a/database/migrations/2026_06_28_020001_create_license_instances_table.php
+++ b/database/migrations/2026_06_28_020001_create_license_instances_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('license_instances', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('license_id')->constrained('licenses')->cascadeOnDelete();
+            $table->string('identifier');
+            $table->string('ip_address')->nullable();
+            $table->timestamp('last_validated_at')->nullable();
+            $table->string('local_key')->nullable();
+            $table->timestamps();
+
+            $table->unique(['license_id', 'identifier']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('license_instances');
+    }
+};

--- a/database/migrations/2026_06_28_020002_create_license_reissues_table.php
+++ b/database/migrations/2026_06_28_020002_create_license_reissues_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('license_reissues', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('license_id')->constrained('licenses')->cascadeOnDelete();
+            $table->foreignId('reissued_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('license_reissues');
+    }
+};

--- a/docs/TASKS-software-licensing.md
+++ b/docs/TASKS-software-licensing.md
@@ -45,44 +45,44 @@ before finalizing.
 
 ### P0 — Core domain + remote validation
 
-- [ ] **L1. `License` model + key generation** (spec 186)
+- [x] **L1. `License` model + key generation** (spec 186)
   - Migration `licenses`: `id`, `team_id` (FK teams, cascade), `customer_id` (FK customers, cascade), `product_service_id` (FK products_services, nullable, nullOnDelete), `license_key` (string, unique), `status` (string, default `active` — `active|suspended|reissue_pending|expired`), `max_instances` (unsignedInteger, default 1), `valid_until` (date, nullable), `notes` (text, nullable), timestamps, softDeletes.
   - `LicenseService::generate(string $prefix = 'LIC', int $segments = 4, int $segmentLength = 5): string` — prefix + grouped random alphanumeric; guarantee uniqueness against the table.
   - Model: `belongsTo(Customer/Team/ProductsService)`, `hasMany(LicenseInstance)`; scopes `active()`.
   - Gate test `test_generating_license_creates_unique_prefixed_key`: assert key starts with prefix, is unique, persists.
 
-- [ ] **L2. Remote validation endpoint** (spec 183, 185, 192) — dep L1
+- [x] **L2. Remote validation endpoint** (spec 183, 185, 192) — dep L1
   - Public route `POST /api/v1/license/validate` (no Sanctum) → `LicenseValidationController`. Input: `license_key`, instance identifier (`domain`/`ip`/`instance_id`). Returns `{valid: bool, status, data}`.
   - `LicenseService::validate(string $key, array $instance): array` — invalid if key missing/suspended/expired; if active, register/refresh the calling instance (L3) and enforce `max_instances`.
   - Gate tests: `test_valid_key_returns_active`, `test_suspended_key_returns_invalid`, `test_exceeding_max_instances_is_rejected`.
 
 ### P1 — Instances, activation, reissue, abuse
 
-- [ ] **L3. `LicenseInstance` tracking (local + remote keys)** (spec 183, 185) — dep L2
+- [x] **L3. `LicenseInstance` tracking (local + remote keys)** (spec 183, 185) — dep L2
   - Migration `license_instances`: `id`, `license_id` (FK, cascade), `identifier` (string — domain/ip/install id), `ip_address` (string, nullable), `last_validated_at` (timestamp), `local_key` (string, nullable — signed offline token so access survives platform downtime), timestamps. Unique (`license_id`,`identifier`).
   - On validate: upsert instance, stamp `last_validated_at`, issue an HMAC-signed `local_key` (TTL) the SDK caches for offline checks.
   - Gate tests: `test_activation_records_instance`, `test_local_key_verifies_offline`.
 
-- [ ] **L4. Reissue + abuse detection** (spec 189, 190) — dep L3
+- [x] **L4. Reissue + abuse detection** (spec 189, 190) — dep L3
   - `LicenseService::reissue(License $license): void` — clears instances, sets status back to `active`, ready for a new install.
   - Abuse guard: block reissue if > N reissues within a window (config). Throw on excess.
   - Gate tests: `test_reissue_clears_instances`, `test_excessive_reissue_is_blocked`.
 
 ### P2 — UI + downloads + SDK
 
-- [ ] **L5. Admin `LicenseResource`** (spec — admin management) — dep L1
+- [x] **L5. Admin `LicenseResource`** (spec — admin management) — dep L1
   - Admin CRUD; row actions **Reissue** and **Suspend/Unsuspend**. Customer + product selects.
   - Gate test `test_admin_can_issue_license`.
 
-- [ ] **L6. Client portal license list** (spec 184, 191) — dep L1
+- [x] **L6. Client portal license list** (spec 184, 191) — dep L1
   - Client `LicenseResource` (read + reissue + view key + download), email-scoped via `getEloquentQuery`.
   - Gate tests: `test_client_sees_only_own_licenses`, `test_client_can_reissue_own_license`.
 
-- [ ] **L7. Download restrictions** (spec 187) — dep L2
+- [x] **L7. Download restrictions** (spec 187) — dep L2
   - A download route/policy that serves a protected file only when the requesting license validates (active + within support/validity). Reuse `LicenseService::validate`.
   - Gate test `test_download_denied_without_valid_license` (assert 403), `test_download_allowed_with_valid_license`.
 
-- [ ] **L8. Copy-paste PHP SDK sample** (spec 182) — dep L2, L3
+- [x] **L8. Copy-paste PHP SDK sample** (spec 182) — dep L2, L3
   - Ship a documented `resources/sdk/license-client.php` sample that calls the validate endpoint and caches the local key. Doc artifact — no automated test (verify by example).
 
 ---

--- a/resources/sdk/license-client.php
+++ b/resources/sdk/license-client.php
@@ -66,7 +66,7 @@ class LiberuLicenseClient
 
     /**
      * @param  array<string, string>  $payload
-     * @return array<string, mixed>|null  null on transport failure
+     * @return array<string, mixed>|null null on transport failure
      */
     private function post(string $path, array $payload): ?array
     {

--- a/resources/sdk/license-client.php
+++ b/resources/sdk/license-client.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Liberu Billing — copy-paste license client.
+ *
+ * Drop this into your licensed application. It validates the license against
+ * the platform and caches a signed offline key so the app keeps working while
+ * the platform is unreachable.
+ *
+ * Usage:
+ *   $client = new LiberuLicenseClient('https://billing.example.com', 'LIC-XXXXX-...');
+ *   if (! $client->check()) { exit('Invalid license.'); }
+ */
+class LiberuLicenseClient
+{
+    private string $cacheFile;
+
+    public function __construct(
+        private string $baseUrl,
+        private string $licenseKey,
+        private ?string $identifier = null,
+    ) {
+        // Identify this install (domain or hostname) so the platform can enforce
+        // the per-license instance limit.
+        $this->identifier = $identifier ?? ($_SERVER['HTTP_HOST'] ?? gethostname());
+        $this->cacheFile = sys_get_temp_dir().'/liberu-license-'.md5($this->licenseKey).'.json';
+    }
+
+    /**
+     * Returns true if the license is valid. Falls back to the cached offline
+     * key when the platform can't be reached.
+     */
+    public function check(): bool
+    {
+        $response = $this->post('/api/v1/license/validate', [
+            'license_key' => $this->licenseKey,
+            'identifier' => $this->identifier,
+        ]);
+
+        if ($response !== null) {
+            $valid = ($response['valid'] ?? false) === true;
+            if ($valid && isset($response['data']['local_key'])) {
+                @file_put_contents($this->cacheFile, json_encode([
+                    'local_key' => $response['data']['local_key'],
+                    'cached_at' => time(),
+                ]));
+            }
+
+            return $valid;
+        }
+
+        // Platform unreachable — trust the cached offline key if present.
+        return $this->hasCachedKey();
+    }
+
+    private function hasCachedKey(): bool
+    {
+        if (! is_file($this->cacheFile)) {
+            return false;
+        }
+
+        $data = json_decode((string) file_get_contents($this->cacheFile), true);
+
+        return is_array($data) && ! empty($data['local_key']);
+    }
+
+    /**
+     * @param  array<string, string>  $payload
+     * @return array<string, mixed>|null  null on transport failure
+     */
+    private function post(string $path, array $payload): ?array
+    {
+        $ch = curl_init($this->baseUrl.$path);
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_HTTPHEADER => ['Content-Type: application/json', 'Accept: application/json'],
+            CURLOPT_POSTFIELDS => json_encode($payload),
+        ]);
+
+        $body = curl_exec($ch);
+        $ok = $body !== false && curl_getinfo($ch, CURLINFO_HTTP_CODE) < 500;
+
+        if (! $ok) {
+            return null;
+        }
+
+        $decoded = json_decode((string) $body, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Api\ClientContactController;
 use App\Http\Controllers\Api\CustomerController;
 use App\Http\Controllers\Api\InvoiceController;
 use App\Http\Controllers\Api\KnowledgeBaseController;
+use App\Http\Controllers\Api\LicenseDownloadController;
+use App\Http\Controllers\Api\LicenseValidationController;
 use App\Http\Controllers\Api\PackageGroupController;
 use App\Http\Controllers\Api\QuoteController;
 use App\Http\Controllers\Api\SubscriptionController;
@@ -158,5 +160,5 @@ Route::prefix('knowledge-base')->group(function (): void {
 });
 
 // Public license endpoints (SDK calls anonymously with a license key)
-Route::post('v1/license/validate', [\App\Http\Controllers\Api\LicenseValidationController::class, 'validateLicense']);
-Route::post('v1/license/download', [\App\Http\Controllers\Api\LicenseDownloadController::class, 'download']);
+Route::post('v1/license/validate', [LicenseValidationController::class, 'validateLicense']);
+Route::post('v1/license/download', [LicenseDownloadController::class, 'download']);

--- a/routes/api.php
+++ b/routes/api.php
@@ -156,3 +156,7 @@ Route::prefix('knowledge-base')->group(function (): void {
     Route::post('articles/{slug}/not-helpful', [KnowledgeBaseController::class, 'markNotHelpful']);
     Route::get('categories/{categoryId}/articles', [KnowledgeBaseController::class, 'byCategory']);
 });
+
+// Public license endpoints (SDK calls anonymously with a license key)
+Route::post('v1/license/validate', [\App\Http\Controllers\Api\LicenseValidationController::class, 'validateLicense']);
+Route::post('v1/license/download', [\App\Http\Controllers\Api\LicenseDownloadController::class, 'download']);

--- a/tests/Feature/Filament/ClientLicenseResourceTest.php
+++ b/tests/Feature/Filament/ClientLicenseResourceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\LicenseStatus;
+use App\Filament\Client\Resources\LicenseResource\Pages\ListLicenses;
+use App\Models\Customer;
+use App\Models\License;
+use App\Models\LicenseInstance;
+use App\Models\User;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ClientLicenseResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actingInClientPanel(User $user): void
+    {
+        $this->actingAs($user);
+        $panel = Filament::getPanel('client');
+        Filament::setCurrentPanel($panel);
+        $panel->boot();
+    }
+
+    public function test_client_sees_only_own_licenses(): void
+    {
+        $user = User::factory()->create(['email' => 'owner@example.com']);
+
+        $mineCustomer = Customer::factory()->create(['email' => 'owner@example.com']);
+        $mine = License::factory()->create(['customer_id' => $mineCustomer->id]);
+
+        $theirsCustomer = Customer::factory()->create(['email' => 'other@example.com']);
+        $theirs = License::factory()->create(['customer_id' => $theirsCustomer->id]);
+
+        $this->actingInClientPanel($user);
+
+        Livewire::test(ListLicenses::class)
+            ->assertSuccessful()
+            ->assertCanSeeTableRecords([$mine])
+            ->assertCanNotSeeTableRecords([$theirs]);
+    }
+
+    public function test_client_can_reissue_own_license(): void
+    {
+        $user = User::factory()->create(['email' => 'owner@example.com']);
+        $customer = Customer::factory()->create(['email' => 'owner@example.com']);
+        $license = License::factory()->create([
+            'customer_id' => $customer->id,
+            'status' => LicenseStatus::Suspended,
+        ]);
+        LicenseInstance::create([
+            'license_id' => $license->id,
+            'identifier' => 'example.com',
+            'last_validated_at' => now(),
+        ]);
+
+        $this->actingInClientPanel($user);
+
+        Livewire::test(ListLicenses::class)
+            ->callAction(TestAction::make('reissue')->table($license));
+
+        $license->refresh();
+        $this->assertSame(LicenseStatus::Active, $license->status);
+        $this->assertSame(0, $license->instances()->count());
+    }
+}

--- a/tests/Feature/Filament/LicenseResourceTest.php
+++ b/tests/Feature/Filament/LicenseResourceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Filament;
+
+use App\Enums\LicenseStatus;
+use App\Filament\Admin\Resources\Licenses\Pages\CreateLicense;
+use App\Models\Customer;
+use App\Models\License;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class LicenseResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_issue_license(): void
+    {
+        $user = User::factory()->withPersonalTeam()->create();
+        $this->actingAs($user);
+
+        $customer = Customer::factory()->create();
+
+        $panel = Filament::getPanel('admin');
+        Filament::setCurrentPanel($panel);
+        $panel->boot();
+        Filament::setTenant($user->currentTeam);
+
+        Livewire::test(CreateLicense::class)
+            ->fillForm([
+                'customer_id' => $customer->id,
+                'status' => LicenseStatus::Active->value,
+                'max_instances' => 1,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $license = License::firstOrFail();
+
+        $this->assertSame($customer->id, $license->customer_id);
+        $this->assertSame($user->currentTeam->id, $license->team_id);
+        $this->assertNotEmpty($license->license_key);
+        $this->assertStringStartsWith('LIC-', $license->license_key);
+    }
+}

--- a/tests/Feature/LicenseDownloadTest.php
+++ b/tests/Feature/LicenseDownloadTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\LicenseStatus;
+use App\Models\License;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class LicenseDownloadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_download_denied_without_valid_license(): void
+    {
+        $license = License::factory()->create(['status' => LicenseStatus::Suspended]);
+
+        $this->postJson('/api/v1/license/download', [
+            'license_key' => $license->license_key,
+            'identifier' => 'host-1',
+        ])->assertForbidden();
+    }
+
+    public function test_download_allowed_with_valid_license(): void
+    {
+        Storage::fake('local');
+        Storage::disk('local')->put('protected/release.zip', 'payload');
+        $license = License::factory()->create();
+
+        $this->post('/api/v1/license/download', [
+            'license_key' => $license->license_key,
+            'identifier' => 'host-1',
+        ])->assertOk();
+    }
+}

--- a/tests/Feature/LicenseReissueTest.php
+++ b/tests/Feature/LicenseReissueTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\LicenseStatus;
+use App\Models\License;
+use App\Models\LicenseInstance;
+use App\Services\LicenseService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use RuntimeException;
+use Tests\TestCase;
+
+class LicenseReissueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_reissue_clears_instances(): void
+    {
+        $license = License::factory()->create(['max_instances' => 2]);
+        LicenseInstance::factory()->create(['license_id' => $license->id, 'identifier' => 'host-1']);
+        LicenseInstance::factory()->create(['license_id' => $license->id, 'identifier' => 'host-2']);
+
+        app(LicenseService::class)->reissue($license);
+
+        $this->assertSame(0, $license->instances()->count());
+        $this->assertSame(LicenseStatus::Active, $license->fresh()->status);
+    }
+
+    public function test_excessive_reissue_is_blocked(): void
+    {
+        config()->set('licensing.reissue_limit', 1);
+        $license = License::factory()->create();
+        $service = app(LicenseService::class);
+
+        $service->reissue($license);
+
+        $this->expectException(RuntimeException::class);
+        $service->reissue($license);
+    }
+}

--- a/tests/Feature/LicenseTest.php
+++ b/tests/Feature/LicenseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\LicenseStatus;
+use App\Models\License;
+use App\Services\LicenseService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LicenseTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generating_license_creates_unique_prefixed_key(): void
+    {
+        $service = app(LicenseService::class);
+
+        $a = $service->generate('ACME');
+        $b = $service->generate('ACME');
+
+        $this->assertStringStartsWith('ACME-', $a);
+        $this->assertNotSame($a, $b);
+    }
+
+    public function test_license_persists_with_active_status_and_key(): void
+    {
+        $license = License::factory()->create();
+
+        $this->assertSame(LicenseStatus::Active, $license->fresh()->status);
+        $this->assertNotEmpty($license->license_key);
+    }
+}

--- a/tests/Feature/LicenseValidationTest.php
+++ b/tests/Feature/LicenseValidationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\LicenseStatus;
+use App\Models\License;
+use App\Services\LicenseService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LicenseValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_valid_key_returns_active(): void
+    {
+        $license = License::factory()->create(['max_instances' => 2]);
+
+        $this->postJson('/api/v1/license/validate', [
+            'license_key' => $license->license_key,
+            'identifier' => 'host-1',
+        ])->assertOk()->assertJson(['valid' => true, 'status' => 'active']);
+    }
+
+    public function test_suspended_key_returns_invalid(): void
+    {
+        $license = License::factory()->create(['status' => LicenseStatus::Suspended]);
+
+        $this->postJson('/api/v1/license/validate', [
+            'license_key' => $license->license_key,
+            'identifier' => 'host-1',
+        ])->assertJson(['valid' => false]);
+    }
+
+    public function test_exceeding_max_instances_is_rejected(): void
+    {
+        $license = License::factory()->create(['max_instances' => 1]);
+
+        $this->postJson('/api/v1/license/validate', [
+            'license_key' => $license->license_key,
+            'identifier' => 'host-1',
+        ])->assertJson(['valid' => true]);
+
+        $this->postJson('/api/v1/license/validate', [
+            'license_key' => $license->license_key,
+            'identifier' => 'host-2',
+        ])->assertJson(['valid' => false]);
+    }
+
+    public function test_activation_records_instance(): void
+    {
+        $license = License::factory()->create();
+
+        app(LicenseService::class)->validate($license->license_key, ['identifier' => 'host-1']);
+
+        $this->assertDatabaseHas('license_instances', [
+            'license_id' => $license->id,
+            'identifier' => 'host-1',
+        ]);
+    }
+
+    public function test_local_key_verifies_offline(): void
+    {
+        $license = License::factory()->create();
+        $service = app(LicenseService::class);
+
+        $result = $service->validate($license->license_key, ['identifier' => 'host-1']);
+        $localKey = $result['data']['local_key'];
+
+        $this->assertTrue($service->verifyLocalKey($license->license_key, 'host-1', $localKey));
+        $this->assertFalse($service->verifyLocalKey($license->license_key, 'host-1', 'tampered'));
+    }
+}


### PR DESCRIPTION
Implements the **Software Licensing** addon from `docs/scope.md` (lines 179–192) — fully greenfield. Plan + TDD notes in `docs/TASKS-software-licensing.md`.

## Tasks
| | Feature |
|---|---|
| L1 | `License` model + `LicenseService::generate` (unique prefixed keys) + `LicenseStatus` enum |
| L2 | Remote validation `POST /api/v1/license/validate` (public) |
| L3 | `LicenseInstance` tracking + `max_instances` enforcement + signed offline (local) keys |
| L4 | `reissue()` with abuse guard (limit per window) + `LicenseReissue` log |
| L5 | Admin `LicenseResource` (CRUD + reissue/suspend, auto key-gen) |
| L6 | Client portal `LicenseResource` (read-only, email-scoped, self-reissue) |
| L7 | License-gated download `POST /api/v1/license/download` |
| L8 | Copy-paste PHP SDK (`resources/sdk/license-client.php`) |

## Notable
- Local/remote dual validation: SDK validates remotely and caches an HMAC-signed offline key so the licensed app keeps working during platform downtime.
- Admin resource is team-scoped (added a `team()` relation to `License`); client resource is email-scoped like `InvoiceResource`.
- Public endpoints live under `/api/v1/...` (first use of the documented `v1` prefix).

## Out of scope (per plan)
- Non-PHP SDK samples (endpoint is language-agnostic; only PHP sample ships).
- Hardened crypto beyond HMAC (HSM/asymmetric) — noted ceiling; offline key has no TTL yet.
- Per-product download routing (single protected artifact for now).

## Tests
14 new feature tests. Full suite: **411 passed, 7 skipped, 0 failed**. Pint clean.