### PR TITLE
test: cover billing cadence + client billing report

### DIFF
--- a/tests/Feature/Services/ClientBillingReportServiceTest.php
+++ b/tests/Feature/Services/ClientBillingReportServiceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Services;
+
+use App\Models\Customer;
+use App\Models\Invoice;
+use App\Models\Payment;
+use App\Services\ClientBillingReportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * Reporting aggregates over a customer's invoices/payments. Everything is
+ * scoped by customer_id, so a second customer's data must never bleed in.
+ * getPaymentTrends() is intentionally untested here — it uses MySQL's
+ * DATE_FORMAT(), which the sqlite test driver does not implement.
+ */
+class ClientBillingReportServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ClientBillingReportService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::parse('2026-07-10 12:00:00'));
+        $this->service = new ClientBillingReportService;
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_payment_status_totals_invoiced_paid_outstanding_and_overdue(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $pendingFuture = Invoice::factory()->create([
+            'customer_id' => $customer->id,
+            'total_amount' => 100,
+            'status' => 'pending',
+            'due_date' => '2026-08-01', // not yet due
+        ]);
+        Invoice::factory()->create([
+            'customer_id' => $customer->id,
+            'total_amount' => 200,
+            'status' => 'pending',
+            'due_date' => '2026-06-01', // past due
+        ]);
+        $paid = Invoice::factory()->create([
+            'customer_id' => $customer->id,
+            'total_amount' => 50,
+            'status' => 'paid',
+            'due_date' => '2026-06-15',
+        ]);
+
+        Payment::factory()->create(['invoice_id' => $pendingFuture->id, 'amount' => 30]);
+        Payment::factory()->create(['invoice_id' => $paid->id, 'amount' => 50]);
+
+        // A different customer's invoice + payment must be excluded from every total.
+        $other = Customer::factory()->create();
+        $otherInvoice = Invoice::factory()->create([
+            'customer_id' => $other->id,
+            'total_amount' => 999,
+            'status' => 'pending',
+            'due_date' => '2026-06-01',
+        ]);
+        Payment::factory()->create(['invoice_id' => $otherInvoice->id, 'amount' => 999]);
+
+        $status = $this->service->getPaymentStatus($customer);
+
+        $this->assertEquals(350, $status['total_invoiced']);   // 100 + 200 + 50
+        $this->assertEquals(80, $status['total_paid']);        // 30 + 50
+        $this->assertEquals(300, $status['total_outstanding']); // pending: 100 + 200
+        $this->assertEquals(200, $status['overdue_amount']);    // pending & past-due: 200
+    }
+
+    public function test_billing_history_maps_paid_amount_and_balance_scoped_to_customer(): void
+    {
+        $customer = Customer::factory()->create();
+
+        $invoice = Invoice::factory()->create([
+            'customer_id' => $customer->id,
+            'invoice_number' => 'INV-0001',
+            'total_amount' => 100,
+            'status' => 'pending',
+            'due_date' => '2026-08-01',
+        ]);
+        Payment::factory()->create(['invoice_id' => $invoice->id, 'amount' => 30]);
+
+        Invoice::factory()->create(['customer_id' => Customer::factory()->create()->id]);
+
+        $history = $this->service->generateBillingHistory($customer);
+
+        $this->assertCount(1, $history); // only this customer's invoice
+        $row = $history->first();
+        $this->assertSame('INV-0001', $row['invoice_number']);
+        $this->assertEquals(30, $row['paid_amount']);
+        $this->assertEquals(70, $row['balance']); // 100 - 30
+        $this->assertSame('pending', $row['status']);
+    }
+
+    public function test_billing_history_start_date_filters_older_invoices(): void
+    {
+        $customer = Customer::factory()->create();
+
+        Invoice::factory()->create([
+            'customer_id' => $customer->id,
+            'created_at' => '2026-01-01',
+            'due_date' => '2026-01-15',
+        ]);
+        Invoice::factory()->create([
+            'customer_id' => $customer->id,
+            'invoice_number' => 'INV-RECENT',
+            'created_at' => '2026-07-01',
+            'due_date' => '2026-07-15',
+        ]);
+
+        $history = $this->service->generateBillingHistory($customer, '2026-06-01');
+
+        $this->assertCount(1, $history);
+        $this->assertSame('INV-RECENT', $history->first()['invoice_number']);
+    }
+}

--- a/tests/Unit/Models/RecurringBillingConfigurationTest.php
+++ b/tests/Unit/Models/RecurringBillingConfigurationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\RecurringBillingConfiguration;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * calculateNextBillingDate() is pure date arithmetic with three branches:
+ * a billing_day still ahead in the current month stays in-month; otherwise it
+ * advances by frequency and (if set) pins the billing day. Clock is frozen so
+ * the assertions are deterministic.
+ */
+class RecurringBillingConfigurationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow(Carbon::parse('2026-07-10 12:00:00'));
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function config(string $frequency, ?int $billingDay): RecurringBillingConfiguration
+    {
+        $config = new RecurringBillingConfiguration;
+        $config->frequency = $frequency;
+        $config->billing_day = $billingDay;
+
+        return $config;
+    }
+
+    public function test_billing_day_still_ahead_this_month_stays_in_month(): void
+    {
+        // day 20 > today's day 10, so it does NOT advance the month.
+        $date = $this->config('monthly', 20)->calculateNextBillingDate();
+
+        $this->assertSame('2026-07-20', $date->toDateString());
+    }
+
+    public function test_passed_billing_day_advances_one_month_then_pins_the_day(): void
+    {
+        // day 5 <= today's day 10, so advance monthly then set the day.
+        $date = $this->config('monthly', 5)->calculateNextBillingDate();
+
+        $this->assertSame('2026-08-05', $date->toDateString());
+    }
+
+    public function test_monthly_without_billing_day_adds_one_month(): void
+    {
+        $date = $this->config('monthly', null)->calculateNextBillingDate();
+
+        $this->assertSame('2026-08-10', $date->toDateString());
+    }
+
+    public function test_quarterly_adds_three_months(): void
+    {
+        $date = $this->config('quarterly', null)->calculateNextBillingDate();
+
+        $this->assertSame('2026-10-10', $date->toDateString());
+    }
+
+    public function test_yearly_adds_one_year(): void
+    {
+        $date = $this->config('yearly', null)->calculateNextBillingDate();
+
+        $this->assertSame('2027-07-10', $date->toDateString());
+    }
+
+    public function test_unknown_frequency_defaults_to_monthly(): void
+    {
+        $date = $this->config('weekly', null)->calculateNextBillingDate();
+
+        $this->assertSame('2026-08-10', $date->toDateString());
+    }
+}


### PR DESCRIPTION
## Coverage: billing cadence + client billing report

Characterization tests for two units that had little/no coverage. No production code changed.

| Class | Lines: before → after |
|-------|----------------------|
| `RecurringBillingConfiguration::calculateNextBillingDate` | 25% → **93.75%** |
| `ClientBillingReportService` | 0% → **73.96%** |

**`RecurringBillingConfiguration`** (6 tests, clock frozen) — every branch of `calculateNextBillingDate`: billing day still ahead this month stays in-month; a passed billing day advances by frequency then pins the day; monthly / quarterly / yearly / unknown-defaults-to-monthly arithmetic.

**`ClientBillingReportService`** (3 tests) — `getPaymentStatus` totals (invoiced / paid / outstanding / overdue) proven scoped to one customer; `generateBillingHistory` paid-amount + balance mapping and the start-date filter.

`getPaymentTrends()` is intentionally left untested: it uses MySQL `DATE_FORMAT()`, which the sqlite test driver doesn't implement — a latent portability gap worth a separate fix.

9 tests, all green. Full suite: 548 passed / 7 skipped.
